### PR TITLE
投稿フォームのスタイルの変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "node-fetch": "^3.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-dropzone": "^14.2.3",
     "react-hot-toast": "^2.4.0",
     "react-router-dom": "^6.8.0",
     "react-scripts": "5.0.1",

--- a/src/components/PageLayout/index.tsx
+++ b/src/components/PageLayout/index.tsx
@@ -6,7 +6,7 @@ import { ReactNode } from "react";
 export const PageLayout: React.FC<{ children: ReactNode }> = ({ children }) => {
   return (
     <Stack
-      spacing={3}
+      spacing={6}
       alignItems={"center"}
       sx={{
         minHeight: "100vh",

--- a/src/pages/PostPage.tsx
+++ b/src/pages/PostPage.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect, useState } from "react";
 import toast, { Toaster } from "react-hot-toast";
-import { Stack, TextField, Typography } from "@mui/material";
+import { Box, Stack, TextField, Typography } from "@mui/material";
 import { useNavigate } from "react-router-dom";
 import { PageLayout } from "../components/PageLayout";
 import { useMutation } from "@tanstack/react-query";
@@ -87,21 +87,6 @@ export const PostPage: FC = () => {
       console.log(acceptedFiles);
     },
   });
-  // プレビューのスタイル
-  const previewImageStyle = {
-    display: "inline-flex", // 画像を横並びにする
-    border: "1px solid #eaeaea", // 枠線の設定
-    margin: 5, // 余白
-    maxWidth: 150, // 最大幅
-    maxHeight: 100, // 最大高さ
-    // boxSizing: "content-box" as const, // 枠線を含めたサイズ
-  };
-  const PreviewImageInner = {
-    display: "flex", // 画像をInnerに合わせる
-    minWidth: 0, // フレックスアイテムがコンテナより小さくなる場合に、内容を折り返すことなく縮小する
-    overflow: "hidden", // 要素の内容がはみ出た場合に、表示しない
-    justifyContent: "center", // 並行方向に中央寄せ
-  };
   useEffect(() => {
     // メモリリークを避けるためにデータURIを削除する。アンマウント時に実行される。
     return () => {
@@ -111,36 +96,30 @@ export const PostPage: FC = () => {
     };
   }, []);
 
-  // ドロップゾーンのスタイル
-  const style = {
-    border: isDragActive ? "2px dashed #2196f3" : "2px dashed #ccc",
-    borderRadius: "10px",
-    width: "100%",
-    display: "flex",
-    justifyContent: "center",
-    alignItems: "center",
-    height: "250px",
-    padding: "20px 0px",
-    backgroundColor: "#fafafa",
-    color: "#a9a9a9",
-    transition: "border .24s ease-in-out",
-  };
-
   return (
     <PageLayout>
       <Stack alignItems="center">
         <Stack alignItems="center" spacing={3} sx={{ width: "70%" }}>
           <Typography variant="h6">画像投稿</Typography>
-          <div {...getRootProps({ style })}>
+          <Box
+            {...getRootProps({
+              style: {
+                border: isDragActive ? "2px dashed #2196f3" : "2px dashed #ccc",
+                borderRadius: "10px",
+                width: "100%",
+                padding: "20px 0px",
+                backgroundColor: "#fafafa",
+                color: "#a9a9a9",
+                transition: "border .24s ease-in-out",
+              },
+            })}
+          >
+            {/* react-dropzoneのチュートリアル通りinputを使用している */}
             <input {...getInputProps()} />
             <Stack alignItems="center" spacing={2}>
               <Typography>ここに画像をドラッグ&ドロップ</Typography>
               {preview ? (
-                <div style={previewImageStyle}>
-                  <div style={PreviewImageInner}>
-                    <img src={preview} />
-                  </div>
-                </div>
+                <img src={preview} style={{ width: 200 }} />
               ) : (
                 <AddIcon sx={{ fontSize: 50 }} />
               )}
@@ -148,7 +127,7 @@ export const PostPage: FC = () => {
                 画像は必須・jpeg, png, webp形式の画像・最大20MBまで
               </Typography>
             </Stack>
-          </div>
+          </Box>
 
           <TextField
             type="text"

--- a/src/pages/PostPage.tsx
+++ b/src/pages/PostPage.tsx
@@ -127,8 +127,8 @@ export const PostPage: FC = () => {
     display: "flex",
     justifyContent: "center",
     alignItems: "center",
-    height: "300px",
-    padding: "10px 30px",
+    height: "250px",
+    padding: "20px 0px",
     backgroundColor: "#fafafa",
     color: "#a9a9a9",
     transition: "border .24s ease-in-out",
@@ -136,56 +136,49 @@ export const PostPage: FC = () => {
 
   return (
     <PageLayout>
-      <Stack alignItems="center" spacing={2}>
-        <Typography variant="h6">画像投稿</Typography>
-        <Stack alignItems="center">
-          <Stack {...getRootProps({ className: "dropzone", style })}>
+      <Stack alignItems="center">
+        <Stack alignItems="center" spacing={3} sx={{ width: "70%" }}>
+          <Typography variant="h6">画像投稿</Typography>
+          <div {...getRootProps({ style })}>
             <input {...getInputProps()} />
             <Stack alignItems="center" spacing={2}>
-              {isDragActive ? (
-                <p>画像を持ってきた時の動き</p>
-              ) : (
-                <p>初期表示されてる動き</p>
-              )}
               <AddIcon sx={{ fontSize: 50 }} />
-              <Typography>
-                Drag & drop file here, or click to select file
-              </Typography>
+              <Typography>ここに画像をドラッグ&ドロップ</Typography>
               <aside>{previewImage}</aside>
+              <Typography variant="caption" color={"gray"}>
+                画像は必須・jpeg, png, webp形式の画像・最大20MBまで
+              </Typography>
             </Stack>
-          </Stack>
-          <Typography variant="overline" color={"gray"}>
-            画像は必須です。jpeg, png, webp形式の画像、最大20MBまで。
-          </Typography>
+          </div>
+
+          <TextField
+            type="text"
+            label="キャプション"
+            multiline
+            minRows={3}
+            fullWidth
+            helperText="キャプションは1000文字まで入力できます"
+            value={captionText}
+            onChange={upCaptionText}
+            disabled={postMutation.isLoading}
+          />
+
+          <LoadingButton
+            variant="contained"
+            startIcon={<UploadIcon />}
+            onClick={() => {
+              if (validate()) {
+                postMutation.mutate();
+              }
+            }}
+            loadingPosition="start"
+            loading={postMutation.isLoading}
+          >
+            投稿する
+          </LoadingButton>
         </Stack>
-
-        <TextField
-          type="text"
-          label="キャプション"
-          multiline
-          minRows={3}
-          sx={{ width: "80%" }}
-          helperText="キャプションは1000文字まで入力できます"
-          value={captionText}
-          onChange={upCaptionText}
-          disabled={postMutation.isLoading}
-        />
-
-        <LoadingButton
-          variant="contained"
-          startIcon={<UploadIcon />}
-          onClick={() => {
-            if (validate()) {
-              postMutation.mutate();
-            }
-          }}
-          loadingPosition="start"
-          loading={postMutation.isLoading}
-        >
-          投稿する
-        </LoadingButton>
+        <Toaster position="top-center" reverseOrder={false} />
       </Stack>
-      <Toaster position="top-center" reverseOrder={false} />
     </PageLayout>
   );
 };

--- a/src/pages/PostPage.tsx
+++ b/src/pages/PostPage.tsx
@@ -102,14 +102,6 @@ export const PostPage: FC = () => {
     overflow: "hidden", // 要素の内容がはみ出た場合に、表示しない
     justifyContent: "center", // 並行方向に中央寄せ
   };
-  // プレビューの設定
-  const previewImage = file && (
-    <div style={previewImageStyle} key={file.name}>
-      <div style={PreviewImageInner}>
-        <img src={preview} />
-      </div>
-    </div>
-  );
   useEffect(() => {
     // メモリリークを避けるためにデータURIを削除する。アンマウント時に実行される。
     return () => {
@@ -142,9 +134,16 @@ export const PostPage: FC = () => {
           <div {...getRootProps({ style })}>
             <input {...getInputProps()} />
             <Stack alignItems="center" spacing={2}>
-              <AddIcon sx={{ fontSize: 50 }} />
               <Typography>ここに画像をドラッグ&ドロップ</Typography>
-              <aside>{previewImage}</aside>
+              {preview ? (
+                <div style={previewImageStyle}>
+                  <div style={PreviewImageInner}>
+                    <img src={preview} />
+                  </div>
+                </div>
+              ) : (
+                <AddIcon sx={{ fontSize: 50 }} />
+              )}
               <Typography variant="caption" color={"gray"}>
                 画像は必須・jpeg, png, webp形式の画像・最大20MBまで
               </Typography>

--- a/src/pages/PostPage.tsx
+++ b/src/pages/PostPage.tsx
@@ -100,7 +100,6 @@ export const PostPage: FC = () => {
     <PageLayout>
       <Stack alignItems="center">
         <Stack alignItems="center" spacing={3} sx={{ width: "70%" }}>
-          <Typography variant="h6">画像投稿</Typography>
           <Box
             {...getRootProps({
               style: {

--- a/src/pages/PostPage.tsx
+++ b/src/pages/PostPage.tsx
@@ -47,16 +47,6 @@ export const PostPage: FC = () => {
       toast.error("画像が選択されていません");
       return false;
     }
-    const fileSizeInMB = file.size / (1024 * 1024);
-    if (fileSizeInMB > 20) {
-      toast.error("画像サイズは20MBまでです");
-      return false;
-    }
-    if (!/^(image\/jpeg|image\/png|image\/webp)$/.test(file.type)) {
-      toast.error("画像はjpeg, png, webpのいずれかで投稿してください");
-      console.log(file);
-      return false;
-    }
     if (captionText.length >= 1000) {
       toast.error("キャプションの文字数は1000文字までです");
       return false;
@@ -69,8 +59,6 @@ export const PostPage: FC = () => {
   };
 
   // ドロップゾーンの設定
-  console.log(file);
-
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     accept: {
       "image/jpeg": [".jpg", ".jpeg"],
@@ -78,10 +66,15 @@ export const PostPage: FC = () => {
       "image/webp": [".webp"],
     },
     maxFiles: 1,
-    // TODO: 画像のファイル形式のトーストも出す
     onDropRejected: (fileRejections) => {
       if (fileRejections.length > 1) {
-        toast.error("画像は1つだけ選択してください");
+        toast.error("投稿できる画像は1つだけです");
+      }
+      if (fileRejections[0].errors[0].code === "file-invalid-type") {
+        toast.error("画像はjpeg, png, webpのいずれかで投稿してください");
+      }
+      if (fileRejections[0].errors[0].code === "file-too-large") {
+        toast.error("画像サイズは20MBまでです");
       }
       console.log(fileRejections);
     },

--- a/src/pages/PostPage.tsx
+++ b/src/pages/PostPage.tsx
@@ -1,12 +1,13 @@
-import { FC, useState } from "react";
+import React, { FC, useCallback, useState } from "react";
 import toast, { Toaster } from "react-hot-toast";
 import { Stack, TextField, Typography } from "@mui/material";
 import { useNavigate } from "react-router-dom";
 import { PageLayout } from "../components/PageLayout";
 import { useMutation } from "@tanstack/react-query";
-import UploadIcon from "@mui/icons-material/Upload";
 import { useLoginCreator } from "./useLoginCreator";
 import { LoadingButton } from "@mui/lab";
+import { useDropzone } from "react-dropzone";
+import { Upload as UploadIcon, Add as AddIcon } from "@mui/icons-material";
 
 export const PostPage: FC = () => {
   const [captionText, setCaptionText] = useState("");
@@ -68,23 +69,32 @@ export const PostPage: FC = () => {
     setPostImage(event.target.files ? event.target.files[0] : null);
   };
 
+  // ドロップゾーンの設定
+  const onDrop = useCallback((acceptedFiles: File[]) => {
+    console.log(acceptedFiles);
+  }, []);
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop });
+  // ドロップゾーンのスタイル
+  const style = {
+    border: isDragActive ? "2px dashed blue" : "2px dashed #ccc",
+    borderRadius: "10px",
+    // width: "100%",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    height: "200px",
+    padding: "30px",
+    backgroundColor: "#fafafa",
+    color: "#a9a9a9",
+    transition: "border .24s ease-in-out",
+  };
+
   return (
     <PageLayout>
       <Stack alignItems="center" spacing={2}>
         <Typography variant="h6">画像投稿</Typography>
 
-        <TextField
-          type="text"
-          label="キャプション"
-          multiline
-          minRows={3}
-          sx={{ width: "80%" }}
-          helperText="キャプションは1000文字まで入力できます"
-          value={captionText}
-          onChange={upCaptionText}
-          disabled={postMutation.isLoading}
-        />
-        <TextField
+        {/* <TextField
           type="file"
           sx={{ width: "80%" }}
           helperText="画像は必須です"
@@ -96,6 +106,37 @@ export const PostPage: FC = () => {
             disableUnderline: true,
           }}
           onChange={upPostImage}
+          disabled={postMutation.isLoading}
+        /> */}
+        <Stack alignItems={"center"}>
+          <div {...getRootProps({ style })}>
+            <input {...getInputProps()} />
+            <Stack alignItems="center" spacing={2}>
+              {isDragActive ? (
+                <p>画像を持ってきた時の動き</p>
+              ) : (
+                <p>初期表示されてる動き</p>
+              )}
+              <AddIcon sx={{ fontSize: 50 }} />
+              <Typography>
+                ここに画像をドラック＆ドロップするか、クリックしてファイルを選択
+              </Typography>
+            </Stack>
+          </div>
+          <Typography variant="overline" color={"gray"}>
+            画像は必須です。jpeg, png, webp形式の画像、最大20MBまで。
+          </Typography>
+        </Stack>
+
+        <TextField
+          type="text"
+          label="キャプション"
+          multiline
+          minRows={3}
+          sx={{ width: "80%" }}
+          helperText="キャプションは1000文字まで入力できます"
+          value={captionText}
+          onChange={upCaptionText}
           disabled={postMutation.isLoading}
         />
 

--- a/src/pages/PostPage.tsx
+++ b/src/pages/PostPage.tsx
@@ -73,35 +73,6 @@ export const PostPage: FC = () => {
   interface FileWithPreview extends File {
     preview: string;
   }
-  // ドロップゾーンの初期化
-  const thumbsContainer = {
-    display: "flex",
-    flexDirection: "row" as const,
-    flexWrap: "wrap" as const,
-    marginTop: 16,
-  };
-  const thumb = {
-    display: "inline-flex",
-    borderRadius: 2,
-    border: "1px solid #eaeaea",
-    marginBottom: 8,
-    marginRight: 8,
-    width: 100,
-    height: 100,
-    padding: 4,
-    boxSizing: "border-box" as const,
-  };
-  const thumbInner = {
-    display: "flex",
-    minWidth: 0,
-    overflow: "hidden",
-  };
-  const img = {
-    display: "block",
-    width: "auto",
-    height: "100%",
-  };
-
   const [files, setFiles] = useState<FileWithPreview[]>([]);
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     accept: {
@@ -121,12 +92,27 @@ export const PostPage: FC = () => {
       );
     },
   });
-  const thumbs = files.map((file: FileWithPreview) => (
-    <div style={thumb} key={file.name}>
-      <div style={thumbInner}>
+  // プレビューのスタイル
+  const previewImageStyle = {
+    display: "inline-flex", // 画像を横並びにする
+    border: "1px solid #eaeaea", // 枠線の設定
+    margin: 5, // 余白
+    maxWidth: 150, // 最大幅
+    maxHeight: 100, // 最大高さ
+    // boxSizing: "content-box" as const, // 枠線を含めたサイズ
+  };
+  const PreviewImageInner = {
+    display: "flex", // 画像をInnerに合わせる
+    minWidth: 0, // フレックスアイテムがコンテナより小さくなる場合に、内容を折り返すことなく縮小する
+    overflow: "hidden", // 要素の内容がはみ出た場合に、表示しない
+    justifyContent: "center", // 並行方向に中央寄せ
+  };
+  // プレビューの設定
+  const previewImage = files.map((file: FileWithPreview) => (
+    <div style={previewImageStyle} key={file.name}>
+      <div style={PreviewImageInner}>
         <img
           src={file.preview}
-          style={img}
           onLoad={() => {
             URL.revokeObjectURL(file.preview);
           }}
@@ -135,15 +121,15 @@ export const PostPage: FC = () => {
     </div>
   ));
   useEffect(() => {
-    // Make sure to revoke the data uris to avoid memory leaks, will run on unmount
+    // メモリリークを避けるためにデータ URI を必ず取り消してください。アンマウント時に実行されます
     return () => files.forEach((file) => URL.revokeObjectURL(file.preview));
   }, []);
 
   // ドロップゾーンのスタイル
   const style = {
-    border: isDragActive ? "2px dashed blue" : "2px dashed #ccc",
+    border: isDragActive ? "2px dashed #2196f3" : "2px dashed #ccc",
     borderRadius: "10px",
-    width: "80%",
+    width: "100%",
     display: "flex",
     justifyContent: "center",
     alignItems: "center",
@@ -174,7 +160,7 @@ export const PostPage: FC = () => {
           disabled={postMutation.isLoading}
         /> */}
 
-        <Stack alignItems={"center"}>
+        <Stack alignItems="center">
           <Stack {...getRootProps({ className: "dropzone", style })}>
             <input {...getInputProps()} />
             <Stack alignItems="center" spacing={2}>
@@ -185,9 +171,9 @@ export const PostPage: FC = () => {
               )}
               <AddIcon sx={{ fontSize: 50 }} />
               <Typography>
-                ここに画像をドラック＆ドロップするか、クリックしてファイルを選択
+                Drag & drop file here, or click to select file
               </Typography>
-              <aside style={thumbsContainer}>{thumbs}</aside>
+              <aside>{previewImage}</aside>
             </Stack>
           </Stack>
           <Typography variant="overline" color={"gray"}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2993,6 +2993,11 @@ at-least-node@^1.0.0:
   resolved "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
+attr-accept@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.2.tgz#646613809660110749e92f2c10833b70968d929b"
+  integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
+
 autoprefixer@^10.4.13:
   version "10.4.13"
   resolved "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz"
@@ -4762,6 +4767,13 @@ file-loader@^6.2.0:
   dependencies:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
+
+file-selector@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.6.0.tgz#fa0a8d9007b829504db4d07dd4de0310b65287dc"
+  integrity sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==
+  dependencies:
+    tslib "^2.4.0"
 
 filelist@^1.0.1:
   version "1.0.4"
@@ -7851,6 +7863,15 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-dropzone@^14.2.3:
+  version "14.2.3"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-14.2.3.tgz#0acab68308fda2d54d1273a1e626264e13d4e84b"
+  integrity sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==
+  dependencies:
+    attr-accept "^2.2.2"
+    file-selector "^0.6.0"
+    prop-types "^15.8.1"
+
 react-error-overlay@^6.0.11:
   version "6.0.11"
   resolved "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz"
@@ -8977,6 +8998,11 @@ tslib@^2.0.3:
   version "2.4.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
+
+tslib@^2.4.0:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
## 解決した問題

投稿フォームにMUIのTextFiledを使用していてドロップゾーンが狭く不便でデザインも古い。選択した画像もテキストでしか見れないため、視覚的にわかりにくい。

## やったこと

- react-doropzoneモジュールを導入
- 投稿したい画像をプレビューする機能を追加
- 全体のレイアウト調整

## やってないこと

- 画像編集のフォームについては、画像投稿とは違った形にするかもしれないので今回はそのままにしている
