### PR TITLE
プロフィールとイラスト一覧の間の空白を追加

### DIFF
--- a/src/pages/CreatorPage.tsx
+++ b/src/pages/CreatorPage.tsx
@@ -41,33 +41,35 @@ export const CreatorPage: React.FC = () => {
 
   return (
     <PageLayout>
-      <Stack
-        direction={"row"}
-        justifyContent={"flex-start"}
-        alignItems={"center"}
-        width={"100%"}
-        spacing={2}
-      >
-        <img
-          src={creatorQuery.data?.iconUrl.replace("normal", "200x200")}
-          width={100}
-        />
-        <Stack>
-          <Typography variant="h5" component="div">
-            {creatorQuery.data?.name}
-          </Typography>
-          <Typography variant="body2" component="div">
-            {creatorQuery.data?.description}
-          </Typography>
+      <Stack spacing={2}>
+        <Stack
+          direction={"row"}
+          justifyContent={"flex-start"}
+          alignItems={"center"}
+          width={"100%"}
+          spacing={2}
+        >
+          <img
+            src={creatorQuery.data?.iconUrl.replace("normal", "200x200")}
+            width={100}
+          />
+          <Stack>
+            <Typography variant="h5" component="div">
+              {creatorQuery.data?.name}
+            </Typography>
+            <Typography variant="body2" component="div">
+              {creatorQuery.data?.description}
+            </Typography>
+          </Stack>
         </Stack>
+        <ImageArray
+          creatorId={creatorId ?? ""}
+          onClick={(imageName: string) => {
+            navigate(`/images/${imageName}`);
+          }}
+          showItemBar={false}
+        />
       </Stack>
-      <ImageArray
-        creatorId={creatorId ?? ""}
-        onClick={(imageName: string) => {
-          navigate(`/images/${imageName}`);
-        }}
-        showItemBar={false}
-      />
     </PageLayout>
   );
 };


### PR DESCRIPTION
## 解決した問題
プロフィールアイコンの色が全面に付いている場合、イラスト一覧との隙間がなく詰まってしまっていた。

## やったこと
- <Stack>で囲み、プロフィールとイラスト一覧の間にスペースを挿入

## やっていないこと
- ページ全体のレイアウト調整など