### PR TITLE
サーバーの開始をstartからdevに変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "dev": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
## 解決した問題
フロントエンドとバックエンドでサーバーの開始の文言が違って混乱していた

## やったこと
- pacage.jsonのscriptsのstartをdevに変更(バックエンド側に統一)

## やっていないこと
- その他設定の変更など
